### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Examples
 
     sl.unit_sat_weight = 18.5
 
-    q_lim = geofound.capacity.capacity_vesics_1975(sl, fd)
+    q_lim = geofound.capacity.capacity_vesic_1975(sl, fd)
     p_max = q_lim * length * width
 
     print(' ')


### PR DESCRIPTION
the typo in Vesic's name was corrected at line 61. the example now works.